### PR TITLE
Modify css file name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-spinner-overlay",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A collection of react loading spinners and loading spinners' overlays",
   "repository": {
     "type": "git",

--- a/src/animation.css
+++ b/src/animation.css
@@ -1,17 +1,3 @@
-body {
-  margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
-}
-
 .rotate-infinite {
   animation: rotate-infinite infinite 1000ms linear;
 }

--- a/src/components/BounceLetterLoader.tsx
+++ b/src/components/BounceLetterLoader.tsx
@@ -1,4 +1,4 @@
-import "../index.css";
+import "../animation.css";
 import React from "react";
 import { Overlay, OverlayProps } from "./common/Overlay";
 

--- a/src/components/CircleSpinner.tsx
+++ b/src/components/CircleSpinner.tsx
@@ -1,4 +1,4 @@
-import "../index.css";
+import "../animation.css";
 import React from "react";
 import { Overlay, OverlayProps } from "./common/Overlay";
 

--- a/src/components/DartsSpinner.tsx
+++ b/src/components/DartsSpinner.tsx
@@ -1,4 +1,4 @@
-import "../index.css";
+import "../animation.css";
 import React from "react";
 import { Overlay, OverlayProps } from "./common/Overlay";
 

--- a/src/components/DotLoader.tsx
+++ b/src/components/DotLoader.tsx
@@ -1,4 +1,4 @@
-import "../index.css";
+import "../animation.css";
 import React from "react";
 import { Overlay, OverlayProps } from "./common/Overlay";
 

--- a/src/components/FerrisWheelSpinner.tsx
+++ b/src/components/FerrisWheelSpinner.tsx
@@ -1,4 +1,4 @@
-import "../index.css";
+import "../animation.css";
 import React from "react";
 import { Overlay, OverlayProps } from "./common/Overlay";
 

--- a/src/components/LineLoader.tsx
+++ b/src/components/LineLoader.tsx
@@ -1,4 +1,4 @@
-import "../index.css";
+import "../animation.css";
 import React from "react";
 import { Overlay, OverlayProps } from "./common/Overlay";
 

--- a/src/components/RouletteSpinner.tsx
+++ b/src/components/RouletteSpinner.tsx
@@ -1,4 +1,4 @@
-import "../index.css";
+import "../animation.css";
 import React from "react";
 import { Overlay, OverlayProps } from "./common/Overlay";
 

--- a/src/components/SimpleSpinner.tsx
+++ b/src/components/SimpleSpinner.tsx
@@ -1,4 +1,4 @@
-import "../index.css";
+import "../animation.css";
 import React from "react";
 import { Overlay, OverlayProps } from "./common/Overlay";
 

--- a/src/components/WindmillSpinner.tsx
+++ b/src/components/WindmillSpinner.tsx
@@ -1,4 +1,4 @@
-import "../index.css";
+import "../animation.css";
 import React from "react";
 import { Overlay, OverlayProps } from "./common/Overlay";
 


### PR DESCRIPTION
Because next.js prohibited importing public css in node_modules at default.